### PR TITLE
Add PropTypes validation for MediaRow component

### DIFF
--- a/Week4/wsk-25-react/src/components/MediaRow.jsx
+++ b/Week4/wsk-25-react/src/components/MediaRow.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 // src/components/MediaRow.jsx
 const MediaRow = (props) => {
   const {item} = props;
@@ -14,6 +15,10 @@ const MediaRow = (props) => {
       <td>{item.media_type}</td>
     </tr>
   );
+};
+
+MediaRow.propTypes = {
+  item: PropTypes.object.isRequired,
 };
 
 export default MediaRow;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Implement PropTypes validation to ensure the 'item' prop is a required object for the MediaRow component